### PR TITLE
Move the .catch function from apiCalls.js to scripts.js

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,12 +1,6 @@
-import {errorMessage} from './scripts.js'
-
 function fetchApiData(url) {
     return fetch(url)
         .then(promise => promise.json())
-        .catch(error => {
-            console.log('oh no!', error)
-            return errorMessage.innerText = error.message;
-        });
 };
 
 export {fetchApiData};

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -22,7 +22,6 @@ const sleepPromise = fetchApiData('https://fitlit-api.herokuapp.com/api/v1/sleep
 
 Promise.all([userPromise, hydrationPromise, sleepPromise])
   .then((value) => {
-    console.log(value)
     setUserData(value[0].userData)
     const thisUser = getUserData();
     userBuildAttributes(thisUser);
@@ -30,7 +29,10 @@ Promise.all([userPromise, hydrationPromise, sleepPromise])
     hydrationBuildAttributes(hydrationRepo);
     setSleepData(value[2].sleepData);
     sleepBuildAttributes(sleepRepo);
-  });
+  })
+  .catch(error => {
+    return errorMessage.innerText = error.message;
+});
 
 const setUserData = (someData) => {
   userRepo = new UserRepository(someData);


### PR DESCRIPTION
# Description

This branch moved the .catch function from the apiCalls.js file to the end of our promise.all function in scripts.js
This helps keep the code DRY as we only call the .catch once for all three promises. I removed two console logs as well.
Code still works the same as it did before. 

## Type of Change:

- [] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (code is working and without bugs, formatting has been streamlined)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

What steps have you taken to ensure the code is effective?
- [x] Have you used Dev Tools/ ran code in the console?
- [x] Have you verified changes using `open index.html`?

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] My commit messages are consistent, descriptive, concise and begin with a verb and capital letter.
- [x] I have performed a self-review of my own code.
- [x] I have added @lourdesbnts @Baskanbetul and @mmartinelli22 as reviewers.